### PR TITLE
optipng replaced input files although a destination was given

### DIFF
--- a/tasks/pngmin.js
+++ b/tasks/pngmin.js
@@ -22,7 +22,7 @@ module.exports = function(grunt) {
         },{
             executable: 'optipng',
             isAvailable: false,
-            flags: ['<inputFile>', '<outputFile>']
+            flags: ['<inputFile>', '-out', '<outputFile>']
         },{
             executable: 'cryopng',
             isAvailable: false,


### PR DESCRIPTION
added missing `-opt` arg
