### PR TITLE
Fix for Sprite Generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test": "grunt lint test --verbose"
   },
   "dependencies": {
+    "async": "~0.1.22",
     "grunt": "~0.3.9",
     "jQuery": ">=1.7.4",
     "which": "~1.0.5",


### PR DESCRIPTION
Howdy, I found a bug (#5) in the sprites task. The last file in the list generated by `src` was always being left out. And in the case where only 1 image exists in a sprite, nothing happens at all.

I opted to use [async.js](https://github.com/caolan/async/) to help control the async flow of reading the files into memory. It shortens the code, makes it more readable, and less prone to "off-by-one" errors such as this one.
