### PR TITLE
0.4 compatibility fix: refactor around grunt.registerHelper no longer being a thing

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,180 +6,184 @@ var fs      = require('fs'),
 
 // Helpers for image tasks
 
-var _ = grunt.util._;
+module.exports = function(grunt) {
+    var exports = {},
+        _       = grunt.util._;
 
-// helper that outputs if executables are missing
-module.exports.noToolInstalled = function(tools, task, cb) {
-    grunt.verbose.or.writeln();
-    grunt.log.write('Running ' + _.pluck(tools, 'executable').join(', ') + '...').error();
+    // helper that outputs if executables are missing
+    exports.noToolInstalled = function(tools, task, cb) {
+        grunt.verbose.or.writeln();
+        grunt.log.write('Running ' + _.pluck(tools, 'executable').join(', ') + '...').error();
 
-    grunt.log.errorlns([
-        'In order for this task to work properly, one of these tools ":tools" must be',
-        'installed and in the system PATH (if you can run one of these commands ":tools" at',
-        'the command line, this task should work)'
-        ].join(' ').replace(/:tools/g, _.pluck(tools, 'executable').join(', ')));
+        grunt.log.errorlns([
+            'In order for this task to work properly, one of these tools ":tools" must be',
+            'installed and in the system PATH (if you can run one of these commands ":tools" at',
+            'the command line, this task should work)'
+            ].join(' ').replace(/:tools/g, _.pluck(tools, 'executable').join(', ')));
 
-    grunt.log.subhead(('Skiping {{task}} task').replace('{{task}}', task));
+        grunt.log.subhead(('Skiping {{task}} task').replace('{{task}}', task));
 
-    // execute callback if given
-    if(_.isFunction(cb)) {
-        cb();
-    }
-};
-
-// helper for batch processing a couple of files with a list of available tools
-module.exports.processImageFiles = function(tools, files, dest, task, done) {
-    var toolsToProcessInf = _.compact(_.map(tools, function (tool) {
-                if (tool.isAvailable === true) {
-                    return tool;
-                }
-            })),
-        toolsToProcess = _.pluck(toolsToProcessInf, 'executable'),
-        numberOfTools = toolsToProcess.length,
-        numberOfFiles = files.length,
-        processableFiles = [],
-        processableTools = [],
-        uncompressedFileSizes = {},
-        compressedFileSizes = {},
-        processFinished = null,
-        processNextFile = null,
-        processNextTool = null,
-        checkMakeDir = null,
-        currentFilesInProcess = {},
-        pathSeparator = process.platform === 'win32' ? '\\' : '/';
-
-
-    // check if there are usable tools
-    if (numberOfTools === 0) {
-        grunt.helper('no tool installed', tools, task, done);
-    }
-
-    processFinished = function () {
-        var overallSizeCompressed = 0,
-            overallSizeUncompressed = 0;
-
-        _.each(uncompressedFileSizes, function (uncompressedSize, file) {
-            overallSizeCompressed += compressedFileSizes[file];
-            overallSizeUncompressed += uncompressedSize;
-        });
-
-        currentFilesInProcess = {};
-        grunt.log.ok('Compressed ' + files.length + ' files');
-        grunt.log.ok('Uncompressed size: ' + (Math.round((overallSizeUncompressed / 1024) * 100) / 100) + 'kb, Compressed size: ' + (Math.round((overallSizeCompressed / 1024) * 100) / 100) + 'kb, Savings: ' + (Math.round((100 - (overallSizeCompressed / overallSizeUncompressed * 100)) * 100) / 100)  + '%');
-        done();
-    };
-
-    processNextFile = function (idx, file, fileOutput) {
-        if (compressedFileSizes[file] > uncompressedFileSizes[file]) {
-            compressedFileSizes[file] = uncompressedFileSizes[file];
-            fs.writeFileSync(fileOutput, currentFilesInProcess[file]);
-        }
-
-
-        if (!_.isUndefined(processableFiles[idx + 1])) {
-            processableFiles[idx + 1]();
-        } else {
-            processFinished();
+        // execute callback if given
+        if(_.isFunction(cb)) {
+            cb();
         }
     };
 
-    processNextTool = function (idx, toolId, file, fileOutput) {
-        if (!_.isUndefined(processableTools[toolId + 1])) {
-            processableTools[toolId + 1](idx, file, fileOutput);
-        } else {
-            setTimeout(function() {
-                compressedFileSizes[file] = String(fs.readFileSync(fileOutput)).length;
-                processNextFile(idx, file, fileOutput);
-            }, 20);
-        }
-    };
-
-    // check if folder exists else create
-    checkMakeDir = function (dir) {
-        try {
-            var stats = fs.lstatSync(dir);
-            if (!stats.isDirectory()) {
-                mkdirp(dir);
-            }
-        } catch (e) {
-            mkdirp(dir);
-        }
-    };
-
-    // generate list of files to process
-    files.forEach(function (file, idx) {
-        var normalizedFile = path.normalize(file),
-
-        fileOutput = path.normalize(dest + normalizedFile.substr(normalizedFile.indexOf(pathSeparator))),
-        dir = path.dirname(fileOutput);
-
-        currentFilesInProcess[file] = fs.readFileSync(file);
-        uncompressedFileSizes[file] = String(currentFilesInProcess[file]).length;
-
-        checkMakeDir(dir);
-        processableFiles.push(function () {
-            processNextTool(idx, -1, file, fileOutput);
-        });
-    });
-
-    // build processable tool stack
-    toolsToProcess.forEach(function (tool, toolId) {
-
-        processableTools.push(function (idx, file, fileOutput) {
-            var flags = _.map(toolsToProcessInf[toolId].flags, function (flag) {
-                var remappedFlags = '';
-
-                switch (flag) {
-                    case '<inputFile>':
-                        remappedFlags = (toolId !== 0 ? fileOutput : file);
-                        break;
-                    case '<outputFile>':
-                        remappedFlags = fileOutput;
-                        break;
-                    case '<outputFolder>':
-                        remappedFlags = path.dirname(fileOutput);
-                        break;
-                    default:
-                        remappedFlags = flag;
-                        break;
-                }
-            return remappedFlags;
-        });
-
-        var ls = grunt.utils.spawn({
-                cmd: tool,
-                args: flags
-            }, function (error, result, code) {
-                var targetFileExists = null;
-                if (error !== null) {
-                    try {
-                        targetFileExists = fs.readFileSync(fileOutput) ? true : false;
-                    } catch (e) {
-                        targetFileExists = false;
+    // helper for batch processing a couple of files with a list of available tools
+    exports.processImageFiles = function(tools, files, dest, task, done) {
+        var toolsToProcessInf = _.compact(_.map(tools, function (tool) {
+                    if (tool.isAvailable === true) {
+                        return tool;
                     }
-                }
-                if (error && !targetFileExists) {
-                    grunt.file.copy(file, fileOutput);
-                    processNextTool(idx, toolId, file, fileOutput);
-                } else {
-                    if (tool === 'pngnq') {
-                        grunt.file.copy(file.replace('.png', '') + '-nq8.png', fileOutput);
-                        fs.unlinkSync(file.replace('.png', '') + '-nq8.png');
-                        processNextTool(idx, toolId, file, fileOutput);
-                    } else {
-                        processNextTool(idx, toolId, file, fileOutput);
-                    }
-                }
+                })),
+            toolsToProcess = _.pluck(toolsToProcessInf, 'executable'),
+            numberOfTools = toolsToProcess.length,
+            numberOfFiles = files.length,
+            processableFiles = [],
+            processableTools = [],
+            uncompressedFileSizes = {},
+            compressedFileSizes = {},
+            processFinished = null,
+            processNextFile = null,
+            processNextTool = null,
+            checkMakeDir = null,
+            currentFilesInProcess = {},
+            pathSeparator = process.platform === 'win32' ? '\\' : '/';
+
+
+        // check if there are usable tools
+        if (numberOfTools === 0) {
+            grunt.helper('no tool installed', tools, task, done);
+        }
+
+        processFinished = function () {
+            var overallSizeCompressed = 0,
+                overallSizeUncompressed = 0;
+
+            _.each(uncompressedFileSizes, function (uncompressedSize, file) {
+                overallSizeCompressed += compressedFileSizes[file];
+                overallSizeUncompressed += uncompressedSize;
             });
 
-        });
-    });
+            currentFilesInProcess = {};
+            grunt.log.ok('Compressed ' + files.length + ' files');
+            grunt.log.ok('Uncompressed size: ' + (Math.round((overallSizeUncompressed / 1024) * 100) / 100) + 'kb, Compressed size: ' + (Math.round((overallSizeCompressed / 1024) * 100) / 100) + 'kb, Savings: ' + (Math.round((100 - (overallSizeCompressed / overallSizeUncompressed * 100)) * 100) / 100)  + '%');
+            done();
+        };
 
-    // kick off file processing
-    if (files.length === 0) {
-        grunt.log.ok('No matching files found!');
-        done();
-    } else {
-        processNextFile(-1, files[-1]);
-    }
+        processNextFile = function (idx, file, fileOutput) {
+            if (compressedFileSizes[file] > uncompressedFileSizes[file]) {
+                compressedFileSizes[file] = uncompressedFileSizes[file];
+                fs.writeFileSync(fileOutput, currentFilesInProcess[file]);
+            }
+
+
+            if (!_.isUndefined(processableFiles[idx + 1])) {
+                processableFiles[idx + 1]();
+            } else {
+                processFinished();
+            }
+        };
+
+        processNextTool = function (idx, toolId, file, fileOutput) {
+            if (!_.isUndefined(processableTools[toolId + 1])) {
+                processableTools[toolId + 1](idx, file, fileOutput);
+            } else {
+                setTimeout(function() {
+                    compressedFileSizes[file] = String(fs.readFileSync(fileOutput)).length;
+                    processNextFile(idx, file, fileOutput);
+                }, 20);
+            }
+        };
+
+        // check if folder exists else create
+        checkMakeDir = function (dir) {
+            try {
+                var stats = fs.lstatSync(dir);
+                if (!stats.isDirectory()) {
+                    mkdirp(dir);
+                }
+            } catch (e) {
+                mkdirp(dir);
+            }
+        };
+
+        // generate list of files to process
+        files.forEach(function (file, idx) {
+            var normalizedFile = path.normalize(file),
+
+            fileOutput = path.normalize(dest + normalizedFile.substr(normalizedFile.indexOf(pathSeparator))),
+            dir = path.dirname(fileOutput);
+
+            currentFilesInProcess[file] = fs.readFileSync(file);
+            uncompressedFileSizes[file] = String(currentFilesInProcess[file]).length;
+
+            checkMakeDir(dir);
+            processableFiles.push(function () {
+                processNextTool(idx, -1, file, fileOutput);
+            });
+        });
+
+        // build processable tool stack
+        toolsToProcess.forEach(function (tool, toolId) {
+
+            processableTools.push(function (idx, file, fileOutput) {
+                var flags = _.map(toolsToProcessInf[toolId].flags, function (flag) {
+                    var remappedFlags = '';
+
+                    switch (flag) {
+                        case '<inputFile>':
+                            remappedFlags = (toolId !== 0 ? fileOutput : file);
+                            break;
+                        case '<outputFile>':
+                            remappedFlags = fileOutput;
+                            break;
+                        case '<outputFolder>':
+                            remappedFlags = path.dirname(fileOutput);
+                            break;
+                        default:
+                            remappedFlags = flag;
+                            break;
+                    }
+                return remappedFlags;
+            });
+
+            var ls = grunt.utils.spawn({
+                    cmd: tool,
+                    args: flags
+                }, function (error, result, code) {
+                    var targetFileExists = null;
+                    if (error !== null) {
+                        try {
+                            targetFileExists = fs.readFileSync(fileOutput) ? true : false;
+                        } catch (e) {
+                            targetFileExists = false;
+                        }
+                    }
+                    if (error && !targetFileExists) {
+                        grunt.file.copy(file, fileOutput);
+                        processNextTool(idx, toolId, file, fileOutput);
+                    } else {
+                        if (tool === 'pngnq') {
+                            grunt.file.copy(file.replace('.png', '') + '-nq8.png', fileOutput);
+                            fs.unlinkSync(file.replace('.png', '') + '-nq8.png');
+                            processNextTool(idx, toolId, file, fileOutput);
+                        } else {
+                            processNextTool(idx, toolId, file, fileOutput);
+                        }
+                    }
+                });
+
+            });
+        });
+
+        // kick off file processing
+        if (files.length === 0) {
+            grunt.log.ok('No matching files found!');
+            done();
+        } else {
+            processNextFile(-1, files[-1]);
+        }
+    };
+    return exports;
 };

--- a/tasks/gifmin.js
+++ b/tasks/gifmin.js
@@ -1,10 +1,11 @@
 var fs      = require('fs'),
     path    = require('path'),
-    which   = require('which');
+    which   = require('which'),
     helpers = require('../lib/helpers');
 
 module.exports = function(grunt) {
-    var _ = grunt.util._;
+    var _ = grunt.util._,
+        processImageFiles = helpers(grunt).processImageFiles;
 
     // list of all executable gif optimizers 
     var gifTools = [{
@@ -38,7 +39,7 @@ module.exports = function(grunt) {
 				gifToolsLookedUp++;
 
 				if (gifToolsLookedUp === gifToolsToCheck) {
-					helpers.processImageFiles(gifTools, giffiles, dest, 'gifmin', done);
+					processImageFiles(gifTools, giffiles, dest, 'gifmin', done);
 				}
 			});
 		});

--- a/tasks/inlineImg.js
+++ b/tasks/inlineImg.js
@@ -4,7 +4,6 @@ var fs      = require('fs'),
 module.exports = function(grunt) {
     var _ = grunt.util._;
 
-
     // inline images as base64 in css files
     var inline_images_css = function(cssFile, config, cb) {
         var imgRegex = /url\s?\(['"]?(.*?)(?=['"]?\))/gi,

--- a/tasks/jpgmin.js
+++ b/tasks/jpgmin.js
@@ -4,7 +4,8 @@ var fs      = require('fs'),
     helpers = require('../lib/helpers');
 
 module.exports = function(grunt) {
-    var _ = grunt.util._;
+    var _ = grunt.util._,
+        processImageFiles = helpers(grunt).processImageFiles;
 
     // list of all executable jpeg optimizers
     var jpgTools = [{
@@ -47,7 +48,7 @@ module.exports = function(grunt) {
 				jpgToolsLookedUp++;
 
 				if (jpgToolsLookedUp === jpgToolsToCheck) {
-					helpers.processImageFiles(jpgTools, jpgfiles, dest, 'jpgmin', done);
+					processImageFiles(jpgTools, jpgfiles, dest, 'jpgmin', done);
 				}
 			});
 		});

--- a/tasks/pngmin.js
+++ b/tasks/pngmin.js
@@ -9,7 +9,8 @@ var fs      = require('fs'),
 
 
 module.exports = function(grunt) {
-    var _ = grunt.util._;
+    var _ = grunt.util._,
+        processImageFiles = helpers(grunt).processImageFiles;
 
     // list of all executable png optimization tools 
     var pngTools = [{
@@ -63,7 +64,7 @@ module.exports = function(grunt) {
                 pngToolsLookedUp++;
 
                 if (pngToolsLookedUp === pngToolsToCheck) {
-                     grunt.helpers.processImageFiles(pngTools, pngfiles, dest, 'pngmin', done);
+                    processImageFiles(pngTools, pngfiles, dest, 'pngmin', done);
                 }
             });
         });

--- a/tasks/pngnq.js
+++ b/tasks/pngnq.js
@@ -4,7 +4,8 @@ var fs      = require('fs'),
     helpers  = require('../lib/helpers');
 
 module.exports = function(grunt) {
-    var _ = grunt.util._;
+    var _ = grunt.util._,
+        processImageFiles = helpers(grunt).processImageFiles;
 
     // list of all executable tools for png quantifying
     var pngQuant = [{
@@ -41,7 +42,7 @@ module.exports = function(grunt) {
 				pngToolsLookedUp++;
 
 				if (pngToolsLookedUp === pngToolsToCheck) {
-					helpers.processImageFiles(pngQuant, pngfiles, dest, 'pngnq', done);
+					processImageFiles(pngQuant, pngfiles, dest, 'pngnq', done);
 				}
 			});
 		});


### PR DESCRIPTION
Grunt deprecated helpers in favor of good 'ol `require` statements, so this reorganization bring us up to 0.4. Nothing changed functionally.
