### PR TITLE
require `mime` for inlineImg task

### DIFF
--- a/tasks/inlineImg.js
+++ b/tasks/inlineImg.js
@@ -1,5 +1,6 @@
 var fs      = require('fs'),
-    path    = require('path');
+    path    = require('path'),
+    mime    = require('mime');
 
 module.exports = function(grunt) {
     var _ = grunt.util._;


### PR DESCRIPTION
Hi there!

Looks like this missing require was causing the task to fail quietly; wondered where all our images went. It actually inlines the files again now.
