### PR TITLE
(inlineImg) Rewrite of main loop

### DIFF
--- a/tasks/inlineImg.js
+++ b/tasks/inlineImg.js
@@ -9,56 +9,112 @@ module.exports = function(grunt) {
     // inline images as base64 in css files
     var inline_images_css = function(cssFile, config, cb) {
         var imgRegex = /url\s?\(['"]?(.*?)(?=['"]?\))/gi,
+            imageFiles = [],
             css = null,
-            img = null,
-            inlineImgPath = null,
-            imgPath = null,
             base = _.isUndefined(config.base) ? '' : config.base,
             processedImages = 0,
-            match = [],
-            mimetype = null;
+            match = [];
 
         // read css file contents
         css = fs.readFileSync(cssFile, 'utf-8');
 
-        // find all occurences of images in the css file
-        while (match = imgRegex.exec(css)) {
-            imgPath = path.join(path.dirname(cssFile), match[1]);
-            inlineImgPath = imgPath;
+        // Class FileMeta
+        // Return an object with file properties that are useful to us
+        function FileMeta (filePath) {
+            this.originalPath = filePath;
+            this.cleanPath = this.removeQueryString(filePath);
+            this.extension = path.extname(this.cleanPath);
+            this.verifiedPath = this.detectPath();
+        }
 
-            // remove any query params from path (for cache busting etc.)
-            if (imgPath.lastIndexOf('?') !== -1) {
-                inlineImgPath = imgPath.substr(0, imgPath.lastIndexOf('?'));
+        // remove any query params from path (for cache busting etc.)
+        FileMeta.prototype.removeQueryString = function (filePath) {
+            if (filePath.lastIndexOf('?') !== -1) {
+                filePath = filePath.substr(0, filePath.lastIndexOf('?'));
             }
-            // make sure that were only importing images
-            if (path.extname(inlineImgPath) !== '.css') {
-                try {
-                    // try to load the file without a given base path,
-                    // if that doesn´t work, try with
-                    try {
-                        img = fs.readFileSync(inlineImgPath, 'base64');
-                    } catch (err) {
-                        img = fs.readFileSync(base + '/' + path.basename(inlineImgPath), 'base64');
-                    }
+            return filePath;
+        };
 
-                    // replace file with bas64 data
-
-                    mimetype = mime.lookup(inlineImgPath);
-
-                    // check file size and ie8 compat mode
-                    if (img.length > 32768 && config.ie8 === true) {
-                        // i hate to write this, but can´t wrap my head around
-                        // how to do this better: DO NOTHING
-                    } else {
-                        css = css.replace(match[1], 'data:' + mimetype + ';base64,' + img);
-                        processedImages++;
-                    }
-                } catch (err) {
-                    // Catch image file not found error
-                    grunt.verbose.error('Image file not found: ' + match[1]);
+        // Path to the CSS file
+        FileMeta.prototype.cssPath = path.dirname(cssFile);
+        // Basepath as optionally supplied
+        FileMeta.prototype.base = base;
+        // try to detect true path according to different methods
+        FileMeta.prototype.detectPath = function () {
+            function verifyPath (filePath) {
+                if (fs.existsSync(filePath)) {
+                    grunt.log.write('Exists:', filePath, '\n');
+                    return filePath;
+                } else {
+                    //grunt.verbose.error('Image file doesn´t exist:', filePath);
                 }
             }
+                // Method 1: "just use the path relative to the CSS"
+            var found = verifyPath(this.cssPath + '/' + this.cleanPath);
+            if (!found) found = verifyPath(this.base + '/' + this.cleanPath);
+            if (!found) found = verifyPath(this.base + '/' + path.basename(this.cleanPath));
+
+                // Method 3: Use the base + only the filename
+                
+            
+            if (!found) {
+                grunt.verbose.error('Image file doesn´t exist:', this.cleanPath);
+            }
+            return found;
+        };
+        FileMeta.prototype.mimetype = function() {
+            return mime.lookup(this.verifiedPath);
+        };
+        FileMeta.prototype.toBase64 = function () {
+            return fs.readFileSync(this.verifiedPath, 'base64');
+        };
+        // End Class FileMeta
+
+        // Useful filters
+        function filterOnlyImage (fileMeta) {
+            var blackList = ['.css', '.eot', '.otf', '.ttf', '.woff'],
+                disallowed = blackList.indexOf(fileMeta.extension) !== -1;
+            
+            if (disallowed) {
+                grunt.verbose.warn('Excluded file:', fileMeta.cleanPath);
+            }
+            return !disallowed;
         }
+
+        function filterOnlyExists (fileMeta) {
+            return fileMeta.verifiedPath;
+        }
+
+        function filterOnlySmall (fileMeta) {
+            if (!config.ie8) {
+                return true;
+            }
+            var stats = fs.statSync(fileMeta.verifiedPath);
+            var result = stats.size <= 32768;
+            if (stats.result) {
+                grunt.verbose.error('Image file not found: ' + match[1]);
+            }
+            return result;
+        }
+        // End useful filters
+
+        // generate the array of images to process
+        while (match = imgRegex.exec(css)) {
+            var file = new FileMeta(match[1]);
+            imageFiles.push(file);
+        }
+
+        imageFiles
+            .filter(filterOnlyImage)
+            .filter(filterOnlyExists)
+            .filter(filterOnlySmall)
+            .forEach(function (fileMeta) {
+                var base64 = fileMeta.toBase64();
+                var mimetype = fileMeta.mimetype();
+                css = css.replace(fileMeta.originalPath, 'data:' + mimetype + ';base64,' + base64);
+                processedImages++;
+            }
+        );
 
         // check if a callback is given
         if (_.isFunction(cb)) {


### PR DESCRIPTION
## Utilize an object FileMeta to contain everything needed for each file.

It keeps the original path and supplies helper functions to do
everything necessary with each file.
## Use functional style to filter the file list
- `filterOnlyImage` Filter out fonts as well as CSS files
- `filterOnlyExists` Filter out files that don’t exist
- `filterOnlySmall` Filter away large files if IE8 mode activated
## Other fixes
- Verify that `fs.exists` instead of opening and using `try…catch`
- The path verification didn’t work in my project. I added a method of
  detecting the path (#52) but kept both the other methods (#50, #54) so
  as not to break any earlier functionality.
