### PR TITLE
generating background-image url with staticImagePath and mapname

### DIFF
--- a/tasks/sprites.js
+++ b/tasks/sprites.js
@@ -51,7 +51,7 @@ module.exports = function(grunt) {
 
             // check if the user registered a static path for images in the config
             if (!!staticImagePath) {
-                imagePath = staticImagePath + path.sep + spriteMap;
+                imagePath = staticImagePath + path.sep + path.basename(spriteMap);
             }
 
             if (path.sep === "\\"){


### PR DESCRIPTION
Fix for issue https://github.com/asciidisco/grunt-imagine/issues/64. We only need basename of spriteMap instead of whole path
